### PR TITLE
Drop i386

### DIFF
--- a/setup/build_secp256k1.sh
+++ b/setup/build_secp256k1.sh
@@ -19,7 +19,7 @@ TARGETDIR_SIMULATOR="$CURRENTPATH/.build/iphonesimulator"
 mkdir -p "$TARGETDIR_SIMULATOR"
 
 (cd src && ./autogen.sh)
-(cd src && ./configure --host=x86_64-apple-darwin CC=`xcrun -find clang` CFLAGS="-O3 -arch i386 -arch x86_64 -isysroot `xcrun -sdk iphonesimulator --show-sdk-path` -fembed-bitcode-marker -mios-simulator-version-min=8.0" CXX=`xcrun -find clang++` CXXFLAGS="-O3 -arch i386 -arch x86_64 -isysroot `xcrun -sdk iphonesimulator --show-sdk-path` -fembed-bitcode-marker -mios-simulator-version-min=8.0" --prefix="$TARGETDIR_IPHONEOS" && make install)
+(cd src && ./configure --host=x86_64-apple-darwin CC=`xcrun -find clang` CFLAGS="-O3 -arch x86_64 -isysroot `xcrun -sdk iphonesimulator --show-sdk-path` -fembed-bitcode-marker -mios-simulator-version-min=8.0" CXX=`xcrun -find clang++` CXXFLAGS="-O3 -arch x86_64 -isysroot `xcrun -sdk iphonesimulator --show-sdk-path` -fembed-bitcode-marker -mios-simulator-version-min=8.0" --prefix="$TARGETDIR_IPHONEOS" && make install)
 (cd src && make distclean > /dev/null)
 (cd src && ./autogen.sh)
 (cd src && ./configure --host=arm-apple-darwin CC=`xcrun -find clang` CFLAGS="-O3 -arch armv7 -arch armv7s -arch arm64 -isysroot `xcrun -sdk iphoneos --show-sdk-path` -fembed-bitcode -mios-version-min=8.0" CXX=`xcrun -find clang++` CXXFLAGS="-O3 -arch armv7 -arch armv7s -arch arm64 -isysroot `xcrun -sdk iphoneos --show-sdk-path` -fembed-bitcode -mios-version-min=8.0" --prefix="$TARGETDIR_SIMULATOR" && make install)


### PR DESCRIPTION
Including i386 causes duplicate architectures in the same fat output file when running pod instal lin wallet-ios

https://app.bitrise.io/build/462fdefe46d4a081#?tab=log